### PR TITLE
Add VAM support

### DIFF
--- a/addon-info.json
+++ b/addon-info.json
@@ -1,0 +1,13 @@
+{
+  "name": "vim-textobj-quote",
+  "description": "Use ‘curly’ quote characters in Vim",
+  "version": "1.0",
+  "repository": {
+    "type": "git", "url": "git://github.com/reedes/vim-textobj-quote.git",
+    "vim_script_nr": 4811,
+    "script-type": "utility"
+  },
+  "dependencies": {
+    "textobj-user": {}
+  }
+}


### PR DESCRIPTION
Add explicit [vam-addon-manager](https://github.com/MarcWeber/vim-addon-manager) support by adding addon-info.json with listed dependencies.

This plugin has a dependency, which is a perfect reason to have VAM support.

addon-info.json documentation: https://github.com/MarcWeber/vim-addon-manager/blob/master/doc/vim-addon-manager-additional-documentation.txt#L430