### PR TITLE
Add `bar`: help autocommands use custom commands

### DIFF
--- a/plugin/textobj/quote.vim
+++ b/plugin/textobj/quote.vim
@@ -61,9 +61,9 @@ if g:textobj#quote#matchit &&
 endif
 
 " commands to toggle key mappings
-command! -nargs=0 Educate call textobj#quote#educate#mapKeys(1)
-command! -nargs=0 NoEducate call textobj#quote#educate#mapKeys(0)
-command! -nargs=0 ToggleEducate call textobj#quote#educate#toggleMappings()
+command! -nargs=0 -bar Educate call textobj#quote#educate#mapKeys(1)
+command! -nargs=0 -bar NoEducate call textobj#quote#educate#mapKeys(0)
+command! -nargs=0 -bar ToggleEducate call textobj#quote#educate#toggleMappings()
 
 " replace quotes in bulk
 nnoremap <Plug>ReplaceWithCurly    :call textobj#quote#replace#replace(1, '')<cr>


### PR DESCRIPTION
Without `-bar`, users must manually call the underlying functions for
`Educate`, `NoEducate`, and `ToggleEducate` in autocommands.

That is, without `-bar` the following won't work:

```vimscript
autocmd vim_config InsertCharPre *.md if v:char == '`' | ToggleEducate | endif
```

You have to do this instead:

```vimscript
autocmd vim_config InsertCharPre *.md if v:char == '`' | call textobj#quote#educate#toggleMappings() | endif
```

Thanks for considering this.