### PR TITLE
Fix test runner and match tests

### DIFF
--- a/tests/match.vader
+++ b/tests/match.vader
@@ -1,5 +1,5 @@
-# NOT WORKING YET FOR REASONS UNEXPLAINED
 Execute (Clean up test environment):
+  let b:match_words=''
   call textobj#quote#init()
 
 ###########################################################

--- a/tests/replace.vader
+++ b/tests/replace.vader
@@ -4,7 +4,7 @@ Execute (Clean up test environment):
   map <silent> \ <Plug>ReplaceWithStraight
 
 ###########################################################
-
+# This test is failing
 Given:
   "It's 'Dr.' Evil, thank you very much."
 
@@ -15,7 +15,7 @@ Expect:
   “It’s ‘Dr.’ Evil, thank you very much.”
 
 ###########################################################
-
+# This test is failing
 Given:
   “It’s ‘Dr.’ Evil, thank you very much.”
 

--- a/tests/run
+++ b/tests/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 VIMRC="$TMPDIR/mini-vimrc"
-SOURCE="$HOME/.vim/bundle/vim-textobj-quote"
+SOURCE="$PWD"
 
 cat > $VIMRC << EOF
 set nocompatible
@@ -14,7 +14,7 @@ endfor
 set rtp+=$SOURCE
 EOF
 
-cd $SOURCE/test
+cd $SOURCE/tests
 vim -u $VIMRC +Vader*
 #vim -u $VIMRC '+Vader!*' && echo Success || echo Failure
 


### PR DESCRIPTION
+ The test runner had a typo (s/test/tests/) and it assumed a specific
  location for this plugin.
+ The match tests were failing in vader, even though the code works in
  the plugin. The problem is that b:match_words is unset in the vader
  environment. If we manually set that to an empty string, the tests
  pass. (I do not think this points to a problem with the code in the
  plugin. I think it's only a result of the vader environment. I may be
  wrong about that though.)
+ Two tests from tests/replace.vim are failing. This code also seems not
  to work in the plugin. I marked them as failing, so that anyone who
  runs the tests doesn't think they broke that feature.

I made these changes while working on a different PR, but I wanted to
submit them separately. Even if the other PR isn't merged, this should
help anyone who wants to work on this plugin.