### PR TITLE
Fix typo, and digraph for '…'.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,7 +24,7 @@ Core features of this plugin:
 Includes four additional features:
 
 * _educate_ - automatic entry of ‘typographic quotes’ from the 'straight quote' keys
-* _replace_ - transform quotes from straight to typographic, and visa versa
+* _replace_ - transform quotes from straight to typographic, and vice versa
 * _matchit_ - `%` matching for typographic quote pairs
 * _surround_ - surround a word or visual selection with quotes
 
@@ -248,7 +248,7 @@ or via your operating system’s keyboard shortcuts.
 | `″`   | `2'`        |                    | double prime
 | `–`   | `-N`        | `Opt-hyphen`       | en dash
 | `—`   | `-M`        | `Shift-Opt-hyphen` | em dash
-| `…`   | `..`        | `Opt-;`            | horizontal ellipsis
+| `…`   | `,.`        | `Opt-;`            | horizontal ellipsis
 | ` `   | `NS`        |                    | non-breaking space
 | `ï`   | `i:`        | `Opt-U` `i`        | lowercase i, umlaut
 | `æ`   | `ae`        | `Opt-'`            | lowercase ae


### PR DESCRIPTION
I know it's not the main purpose of this project, but I found the basic primer for vim digraphs really helpful while looking into my options for typing proper quotes. I noticed a minor error while trying them out -- the original here is the digraph for '‥', rather than '…'.

From `digraph.txt`:
```
‥       ..      2025    8229    TWO DOT LEADER
…       ,.      2026    8230    HORIZONTAL ELLIPSIS
```

